### PR TITLE
fix: no steam menu entry on latest SteamOS stable

### DIFF
--- a/src/patches/menuPatch.tsx
+++ b/src/patches/menuPatch.tsx
@@ -11,7 +11,8 @@ import { tabManager } from '../classes/TabManager'
 interface MainMenuItemPropsBase {
     route: string
     label: ReactNode
-    onFocus: () => void
+    onFocus?: () => void
+    onGamepadFocus?: () => void
     icon?: ReactElement
     onActivate?: () => void
 }
@@ -38,7 +39,7 @@ export const patchMenu = () => {
             ret.props.children.props.children[0].type = patchedInnerMenu
         } else {
             afterPatch(ret.props.children.props.children[0], 'type', (_: any, ret: any) => {
-                const isMenuItemElt = (e: any) => e.props?.label && e.props.onFocus && e.props.route && e.type?.toString;
+                const isMenuItemElt = (e: any) => e.props?.label && (e.props.onFocus || e.props.onGamepadFocus) && e.props.route && e.type?.toString;
                 const menuItems = findInReactTree(ret, node => Array.isArray(node) && node.some(isMenuItemElt)) as Array<any>;
                 
                 if (!menuItems) {
@@ -55,6 +56,7 @@ export const patchMenu = () => {
                         route={routePath}
                         label='Browser'
                         onFocus={menuItem.props.onFocus}
+                        onGamepadFocus={menuItem.props.onGamepadFocus}
                         useIconAsProp={!!menuItem.props.icon}
                         MenuItemComponent={menuItem.type}
                     />


### PR DESCRIPTION
Fixes the menu patch so that the Browser appears on the steam menu.
#37 #40 

Attached zip with new build
[DeckWebBrowser.zip](https://github.com/user-attachments/files/29419451/DeckWebBrowser.zip)


Fix copied from @marios8543 [commit](https://github.com/marios8543/Deckcord/pull/28/changes/072ae66202ab32b679a6e8d64262c4d5f6fc4adf) on Deckord for the same issue.